### PR TITLE
add support for poll(2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,12 @@ msleep(n)
 	(it uses the linux nanosleep() function)
 	return value: true on success, or (nil, error msg)
 
+poll(pollfds, timeout)
+    waits for readiness events (descriptor becomes readable/writable)
+	in each of pollfds, which is a raw array of pollfd structs
+	(see poll(2) manual page). Returns the modified pollfds array
+	and the number of ready descriptors as multiple values.
+
 ```
 
 ### License

--- a/echoclient.lua
+++ b/echoclient.lua
@@ -49,6 +49,12 @@ function test(what)
 	r, msg = ms.write(sfd, req)
 	printv("echoclient sends on fd ".. sfd .. ":", req)
 
+	pollfds, numfds = ms.poll(string.pack("iHH", sfd, 1, 0), 1000)
+	if numfds > 0 then
+		printv("poll on " .. sfd .. " returned ready")
+		printv(string.unpack("iHH", pollfds))
+	end
+
 	resp, msg = ms.read(sfd)
 	if not resp then print("echoclient:", msg); goto exit end
 

--- a/minisock.c
+++ b/minisock.c
@@ -16,6 +16,7 @@ Functions:
   getaddrinfo  get a list of addresses corresponding to a hostname and port
   getnameinfo  get the hostname and port for a socket
   msleep       sleep for some time in milliseconds
+  poll         wait for a file descriptor to become ready
 
 bind() and connect() use raw sockaddr structures passed as a string.
 Hostname/port translation to a sockaddr is left to the application. 
@@ -520,6 +521,21 @@ int ll_msleep(lua_State *L) {
 } //ll_msleep
 
 
+int ll_poll(lua_State *L) {
+        // wait for some event on a file descriptor
+	// Lua args:
+	//   fds - a raw array of pollfd structures
+        //   timeout - the timeout value in milliseconds as an integer
+	// return values: new pollfds, number of pollfds with events
+	size_t fdslen;
+	struct pollfd *fds = (struct pollfd *) luaL_checklstring(L, 1, &fdslen); // raw pollfd[]
+	int timeout = luaL_checkinteger(L, 2);
+	int n = poll(fds, fdslen / sizeof(struct pollfd), timeout);
+	lua_pushlstring(L, (char *) fds, fdslen);
+	lua_pushinteger(L, n);
+	return 2;
+} //ll_poll
+
 // ---------------------------------------------------------------------
 // Lua library function
 
@@ -542,7 +558,8 @@ static const struct luaL_Reg minisocklib[] = {
 	{"getnameinfo", ll_getnameinfo},
 	// misc
 	{"msleep", ll_msleep},
-	
+	{"poll", ll_poll},
+
 	{NULL, NULL},
 };
 


### PR DESCRIPTION
Thank you for this library!  I was very happy to find a Lua socket library that attempts to do as liitle as possible in C, as I much prefer using a high-level language wherever I can :-)

This PR adds support for poll(2) to detect readiness on file descriptors without blocking, which makes possible to construct an event loop in Lua that can process multiple filehandles at the same time.  I've added an example to echoclient for illustration, although it's a bit unnecessary because it's perfectly happy to block anyway.

poll() conforms to POSIX.1-2001 and POSIX.1-2008 so possibly this won't buuld on very old unixlikes?